### PR TITLE
add: datadog integration with kafka example

### DIFF
--- a/datadog/README.md
+++ b/datadog/README.md
@@ -1,0 +1,49 @@
+# Send metrics from your Aiven services to Datadog
+
+Datadog is an observability platform that includes products for ingesting logs and metrics for monitoring. 
+You can use Aiven's integration with Datadog to send metris from your Aiven services to external Datadog dashboards.
+
+This example creates an Aiven for Apache Kafka® service in one of your projects and a Datadog integration endpoint 
+to send the data from the service to your Datadog dashboards.
+
+## Prerequisites
+
+- A Datadog account
+- A Datadog [API key](https://docs.datadoghq.com/account_management/api-app-keys/)
+- An Aiven project
+
+## Set up the Terraform project
+
+1. Add values for the variables in the `terraform.tfvars` file. You can get the parameter for your
+   Datadog site from the [Datadog documentation](https://docs.datadoghq.com/getting_started/site/)..
+
+2. In the `service.tf` file, add your project's name to the `aiven_project` data source.
+
+3. To initialize Terraform, run:
+
+   ```sh
+   $ terraform init
+   ```
+
+4. To preview the changes, run:
+
+   ```sh
+   $ terraform plan
+
+   ```
+
+5. To deploy your changes, run:
+
+   ```sh
+   $ terraform apply --auto-approve
+   ```
+
+## Verify the setup
+
+You can see your service and integration in the [Aiven Console](https://console.aiven.io/):
+
+1. In the project, select the Kafka service.
+
+2. Click **Integrations** to see your Datadog integration.
+
+In Datadog, you can see the metrics on your dashboards.

--- a/datadog/provider.tf
+++ b/datadog/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=0.13"
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=4.0.0, <5.0.0"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_token
+}

--- a/datadog/service.tf
+++ b/datadog/service.tf
@@ -1,0 +1,35 @@
+# Your Aiven project.
+data "aiven_project" "main" {
+  project = "PROJECT_NAME"
+}
+
+# Add a Datadog integration endpoint. 
+resource "aiven_service_integration_endpoint" "datadog" {
+  project       = data.aiven_project.main.project
+  endpoint_name = "Datadog"
+  endpoint_type = "datadog"
+
+  datadog_user_config {
+    datadog_api_key = var.datadog_api_key
+    datadog_tags {
+      tag = "env:test"
+    }
+    site = var.datadog_site
+  }
+}
+
+# Create an Aiven for Apache Kafka® service.
+resource "aiven_kafka" "example_kafka" {
+  project      = data.aiven_project.main.project
+  cloud_name   = "google-europe-west1"
+  plan         = "business-4"
+  service_name = "kafka-datadog-integration-example"
+}
+
+# Integrate Datadog with the Kafka service.
+resource "aiven_service_integration" "kafka_datadog_metrics" {
+  project                 = data.aiven_project.main.project
+  destination_endpoint_id = aiven_service_integration_endpoint.datadog.id
+  integration_type        = "datadog"
+  source_service_name     = aiven_kafka.example_kafka.service_name
+}

--- a/datadog/terraform.tfvars
+++ b/datadog/terraform.tfvars
@@ -1,0 +1,3 @@
+aiven_token     = "AIVEN_TOKEN"
+datadog_api_key = "DATADOG_API_KEY"
+datadog_site    = "DATADOG_SITE_PARAMETER"

--- a/datadog/variables.tf
+++ b/datadog/variables.tf
@@ -1,0 +1,15 @@
+variable "aiven_token" {
+  description = "Aiven token"
+  type        = string
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API Key"
+  sensitive   = true
+  type        = string
+}
+
+variable "datadog_site" {
+  description = "Datadog site for your account"
+  type        = string
+}


### PR DESCRIPTION
# About this change - What it does

Adds the Datadog example for sending metrics from a Kafka service. 

