### PR TITLE
Add ClickHouse managed credentials examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+### Terraform template
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.terraform.lock.hcl
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Mac meta files
+.DS_Store
+
+# Editors
+.vscode
+.idea

--- a/clickhouse/clickhouse_integrations/credentials/README.md
+++ b/clickhouse/clickhouse_integrations/credentials/README.md
@@ -1,0 +1,19 @@
+# ClickHouse managed credentials
+
+This example creates a ClickHouse cluster and integrates it with credentials stored as service integration endpoints.
+
+The integration endpoint with your S3 bucket is defined by the S3 URL and access keys stored in Terraform variables. 
+The endpoint is made available to the ClickHouse cluster through a [managed credentials integration](https://aiven.io/docs/products/clickhouse/concepts/data-integration-overview#managed-credentials-integration).
+
+Aiven for PostgreSQL, MySQL, and ClickHouse services are created to show how remote databases would be integrated. 
+Managed credentials allow ClickHouse users to access them with the PostgreSQL and MySQL table engines, and the `remoteSecure` function respectively.
+
+## Verify the changes in the Aiven Console
+
+You can see the services, integration endpoints and managed credentials integrations in the [Aiven Console](https://console.aiven.io/):
+
+1. In the `clickhouse-managed-credentials-demo` project's services list, you can see the ClickHouse, PostgreSQL, and MySQL services.
+2. Click **Integration endpoints** to see the S3, external ClickHouse, PostgreSQL, and MySQL endpoints.
+3. Click **Services** and select the `clickhouse-gcp-eu` service.
+4. To view the managed credentials go to the **Integrations** section.
+5. To see the four integrations, go to the **Data pipeline** section.

--- a/clickhouse/clickhouse_integrations/credentials/clickhouse.tf
+++ b/clickhouse/clickhouse_integrations/credentials/clickhouse.tf
@@ -1,0 +1,28 @@
+resource "aiven_clickhouse" "clickhouse" {
+  project      = aiven_project.clickhouse_managed_credentials_demo
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-16"
+  service_name = "clickhouse-gcp-eu"
+}
+
+# Second ClickHouse service, used to showcase integrating with an external cluster
+
+resource "aiven_clickhouse" "external_clickhouse" {
+  project      = aiven_project.clickhouse_managed_credentials_demo
+  cloud_name   = "google-europe-west1"
+  plan         = "startup-16"
+  service_name = "external-clickhouse-gcp-eu"
+}
+
+resource "aiven_service_integration_endpoint" "external_clickhouse" {
+  project       = aiven_project.clickhouse_managed_credentials_demo
+  endpoint_name = "external-clickhouse"
+  endpoint_type = "external_clickhouse"
+
+  external_clickhouse_user_config {
+    host     = aiven_clickhouse.external_clickhouse.service_host
+    port     = aiven_clickhouse.external_clickhouse.service_port
+    username = aiven_clickhouse.external_clickhouse.service_username
+    password = aiven_clickhouse.external_clickhouse.service_password
+  }
+}

--- a/clickhouse/clickhouse_integrations/credentials/credentials-integrations.tf
+++ b/clickhouse/clickhouse_integrations/credentials/credentials-integrations.tf
@@ -1,0 +1,32 @@
+# ClickHouse credentials integrations with endpoints defined in clickhouse.tf, mysql.tf and postgres.tf
+# Each integration will result in a new named collection being created in the ClickHouse service.
+
+resource "aiven_service_integration" "s3_managed_credentials" {
+  project                  = aiven_project.clickhouse_managed_credentials_demo
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.s3_bucket.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+resource "aiven_service_integration" "external_postgres_managed_credentials" {
+  project                  = aiven_project.clickhouse_managed_credentials_demo
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_postgres.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+resource "aiven_service_integration" "external_mysql_managed_credentials" {
+  project                  = aiven_project.clickhouse_managed_credentials_demo
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_mysql.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+
+
+resource "aiven_service_integration" "external_clickhouse_managed_credentials" {
+  project                  = aiven_project.clickhouse_managed_credentials_demo
+  integration_type         = "clickhouse_credentials"
+  source_endpoint_id       = aiven_service_integration_endpoint.external_clickhouse.id
+  destination_service_name = aiven_clickhouse.clickhouse.service_name
+}
+

--- a/clickhouse/clickhouse_integrations/credentials/mysql.tf
+++ b/clickhouse/clickhouse_integrations/credentials/mysql.tf
@@ -1,0 +1,21 @@
+# MySQL service based in GCP US East
+resource "aiven_mysql" "external_mysql" {
+  project      = aiven_project.clickhouse_managed_credentials_demo
+  service_name = "external-mysql-gcp-us"
+  cloud_name   = "google-us-east4"
+  plan         = "business-8"
+}
+
+resource "aiven_service_integration_endpoint" "external_mysql" {
+  project       = aiven_project.clickhouse_managed_credentials_demo
+  endpoint_name = "external-mysql"
+  endpoint_type = "external_mysql"
+
+  external_mysql_user_config {
+    host     = aiven_mysql.external_mysql.service_host
+    port     = aiven_mysql.external_mysql.service_port
+    username = aiven_mysql.external_mysql.service_username
+    password = aiven_mysql.external_mysql.service_password
+  }
+}
+

--- a/clickhouse/clickhouse_integrations/credentials/postgres.tf
+++ b/clickhouse/clickhouse_integrations/credentials/postgres.tf
@@ -1,0 +1,21 @@
+# Postgres service based in GCP US East
+resource "aiven_pg" "external_postgres" {
+  project      = aiven_project.clickhouse_managed_credentials_demo
+  service_name = "external-postgres-gcp-us"
+  cloud_name   = "google-us-east4"
+  plan         = "business-8" # Primary and read replica
+}
+
+resource "aiven_service_integration_endpoint" "external_postgres" {
+  project       = aiven_project.clickhouse_managed_credentials_demo
+  endpoint_name = "external-postgresql"
+  endpoint_type = "external_postgresql"
+
+  external_postgresql {
+    host     = aiven_pg.external_postgres.service_host
+    port     = aiven_pg.external_postgres.service_port
+    username = aiven_pg.external_postgres.service_username
+    password = aiven_pg.external_postgres.service_password
+  }
+}
+

--- a/clickhouse/clickhouse_integrations/credentials/project.tf
+++ b/clickhouse/clickhouse_integrations/credentials/project.tf
@@ -1,0 +1,3 @@
+resource "aiven_project" "clickhouse_managed_credentials_demo" {
+  project = "clickhouse-managed-credentials-demo"
+}

--- a/clickhouse/clickhouse_integrations/credentials/provider.tf
+++ b/clickhouse/clickhouse_integrations/credentials/provider.tf
@@ -1,0 +1,15 @@
+# Initialize the provider
+
+terraform {
+  required_version = ">=0.13"
+  required_providers {
+    aiven = {
+      source  = "aiven/aiven"
+      version = ">=4.25.0, <5.0.0"
+    }
+  }
+}
+
+provider "aiven" {
+  api_token = var.aiven_api_token
+}

--- a/clickhouse/clickhouse_integrations/credentials/s3.tf
+++ b/clickhouse/clickhouse_integrations/credentials/s3.tf
@@ -1,0 +1,13 @@
+# S3 bucket that can hold data in formats that ClickHouse can read from,
+# eg. CSV, Parquet, ORC, JSON, Avro
+resource "aiven_service_integration_endpoint" "s3_bucket" {
+  project       = aiven_project.clickhouse_managed_credentials_demo
+  endpoint_name = "s3-bucket"
+  endpoint_type = "external_aws_s3"
+
+  external_aws_s3_user_config {
+    access_key_id     = var.s3_bucket_access_key
+    secret_access_key = var.s3_bucket_secret_key
+    url               = var.s3_bucket_url
+  }
+}

--- a/clickhouse/clickhouse_integrations/credentials/variables.tf
+++ b/clickhouse/clickhouse_integrations/credentials/variables.tf
@@ -1,0 +1,21 @@
+variable "aiven_api_token" {
+  description = "Aiven API token"
+  type        = string
+  sensitive = true
+}
+
+variable "s3_bucket_access_key" {
+  default = "AKIAIOSFODNN7EXAMPLE"
+  type        = string
+}
+
+variable "s3_bucket_secret_key" {
+  default = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  type        = string
+  sensitive = true
+}
+
+variable "s3_bucket_url" {
+  default = "https://mybucket.s3-myregion.amazonaws.com/mydataset/"
+  type        = string
+}


### PR DESCRIPTION
## About this change—what it does

Adds examples using the newly released Managed Credentials integration, which allows connecting a ClickHouse cluster with S3 buckets and remote Postgres, MySQL & ClickHouse services.

## Why this way
Chose to define the `aiven_service_integration_endpoint` close to each service, and the `clickhouse_credentials` of type `aiven_service_integration` in a single file. Let me know if the resource organization is not intuitive or could be improved!

PR moved from https://github.com/aiven/terraform-provider-aiven/pull/1848